### PR TITLE
Fix temperature and humidity getters to return raw state

### DIFF
--- a/src/area-card/TempHum.ts
+++ b/src/area-card/TempHum.ts
@@ -15,7 +15,7 @@ export class TempHum extends LitElement {
 
   get temperature(): number | undefined {
     return this.tempState?.state !== undefined
-      ? Math.round(parseFloat(this.tempState.state))
+      ?this.tempState.state
       : undefined
   }
   get temperatureUnits(): string | undefined {
@@ -28,7 +28,7 @@ export class TempHum extends LitElement {
 
   get humidity(): number | undefined {
     return this.humState?.state !== undefined
-      ? Math.round(parseFloat(this.humState.state))
+      ? this.humState.state
       : undefined
   }
 


### PR DESCRIPTION
Why format the temperature and humidity before display ?
Might as well get the format chosen in the entities 