### PR TITLE
fix(area-card): support YAML array colors in graph rendering

### DIFF
--- a/src/__tests__/area-card/AreaCard.test.ts
+++ b/src/__tests__/area-card/AreaCard.test.ts
@@ -89,12 +89,32 @@ describe('ScAreaCard', () => {
       expect(element['areaColor']).toBe('#ff0000')
     })
 
-    it('should use default color if no custom color', () => {
-      const config = createMockAreaCardConfig({ color: undefined })
+    it('should handle color array properly', () => {
+      const config = createMockAreaCardConfig({ color: [142, 26, 26] as unknown as string })
       element.setConfig(config)
       element.hass = mockHass
-      const color = element['areaColor']
-      expect(color).toBeDefined()
+      expect(element['areaColor']).toBe('#8e1a1a')
+    })
+
+    it('should use area preset color if no custom color is provided', () => {
+      const config = createMockAreaCardConfig({ color: undefined })
+      element.setConfig(config)
+      element.style.setProperty('--blue', '#0000ff')
+      element.hass = mockHass
+      expect(element['areaColor']).toBe('#0000ff')
+    })
+
+    it('should use #999 when neither custom nor area preset color exists', () => {
+      const customHass = createMockHassWithAreas({
+        office: {
+          ...mockHass.areas.office,
+          area_id: 'unknown-area',
+        },
+      })
+      const config = createMockAreaCardConfig({ color: undefined })
+      element.setConfig(config)
+      element.hass = customHass
+      expect(element['areaColor']).toBe('#999999')
     })
   })
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { getBaseColor } from '../utils'
+
+describe('utils', () => {
+  describe('getBaseColor', () => {
+    it('should return valid hex color when passed a valid hex string', () => {
+      const mockElement = document.createElement('div')
+      expect(getBaseColor(mockElement, '#ff0000')).toBe('#ff0000')
+    })
+
+    it('should return valid hex color when passed a 3-digit hex string', () => {
+      const mockElement = document.createElement('div')
+      expect(getBaseColor(mockElement, '#f00')).toBe('#ff0000')
+    })
+
+    it('should handle numeric array for color', () => {
+      const mockElement = document.createElement('div')
+      // Array configuration from yaml often comes through as number array
+      expect(getBaseColor(mockElement, [142, 26, 26])).toBe('#8e1a1a')
+    })
+
+    it('should correctly format numeric arrays with single digit hex values', () => {
+      const mockElement = document.createElement('div')
+      // e.g. 10 -> 0a
+      expect(getBaseColor(mockElement, [10, 200, 5])).toBe('#0ac805')
+    })
+
+    it('should retrieve custom property from element', () => {
+      const mockElement = document.createElement('div')
+      mockElement.style.setProperty('--my-color', '#123456')
+      document.body.appendChild(mockElement)
+
+      expect(getBaseColor(mockElement, 'var(--my-color)')).toBe('#123456')
+
+      document.body.removeChild(mockElement)
+    })
+  })
+})

--- a/src/area-card/AreaCard.ts
+++ b/src/area-card/AreaCard.ts
@@ -1,7 +1,7 @@
 import { actionHandler } from '@/action-handler-directive'
 import { areaColors } from '@/area-colors'
 import type { Area } from '@/types.ts'
-import { toArray } from '@/utils'
+import { toArray, getBaseColor } from '@/utils'
 import {
   type ActionHandlerEvent,
   handleAction,
@@ -106,7 +106,8 @@ export class ScAreaCard extends LitElement {
   }
 
   get areaColor() {
-    return this._config?.color || (this.area?.area_id && areaColors[this.area.area_id]) || '#999'
+    const color = this._config?.color || (this.area?.area_id && areaColors[this.area.area_id]) || '#999'
+    return getBaseColor(this, color as string | number[])
   }
   get summaryTypes(): EntityTypeSummary[] {
     // Migrate deprecated preset fields to summaries

--- a/src/area-card/TempHumChart.ts
+++ b/src/area-card/TempHumChart.ts
@@ -27,7 +27,7 @@ export class TempHumChart extends LitElement {
 
   private getTempHumStats() {
     // Check if we have already retrieved the statistics
-    const cachedStats = cache.get(this.cacheKey)
+    const cachedStats = cache.get<typeof this.tempHumStats>(this.cacheKey)
     if (cachedStats) {
       this.tempHumStats = cachedStats
       return

--- a/src/area-card/types.ts
+++ b/src/area-card/types.ts
@@ -14,7 +14,7 @@ export interface ScAreaCardConfig extends LovelaceCardConfig {
   area: string
   style?: 'header' | 'full'
   variant?: 'default' | 'compact' | 'mini'
-  color?: string
+  color?: string | number[]
   summary?: EntityTypeSummary | EntityTypeSummary[]
   tap_action?: ActionConfig
   hold_action?: ActionConfig

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-export const getBaseColor = (el: Element, color: string): string => {
+export const getBaseColor = (el: Element, color: string | number[]): string => {
   const normalizeHexColor = (hex: string): string => {
     // Check if it's a 3-digit hex color
     if (/^#([0-9a-f]{3})$/i.test(hex)) {
@@ -7,13 +7,24 @@ export const getBaseColor = (el: Element, color: string): string => {
     return hex
   }
 
+  if (Array.isArray(color)) {
+    const hexColor = color
+      .slice(0, 3)
+      .map((c) => {
+        const hex = Number(c).toString(16)
+        return hex.length === 1 ? '0' + hex : hex
+      })
+      .join('')
+    return normalizeHexColor('#' + hexColor)
+  }
+
   let value = color
 
-  if (color.startsWith('var(')) {
+  if (typeof color === 'string' && color.startsWith('var(')) {
     value = getComputedStyle(el).getPropertyValue(color.replace('var(', '').replace(')', '')).trim()
   }
 
-  return normalizeHexColor(value)
+  return normalizeHexColor(value as string)
 }
 
 export function toArray<T>(value: T | T[] | undefined): T[] {
@@ -29,7 +40,7 @@ const BLUE = 0.0722
 
 const GAMMA = 2.4
 
-export function colorToDec(el: Element, color: string): [number, number, number] {
+export function colorToDec(el: Element, color: string | number[]): [number, number, number] {
   const baseColor = getBaseColor(el, color)
 
   // Extract the r, g, b components from the #rrggbb string
@@ -40,7 +51,7 @@ export function colorToDec(el: Element, color: string): [number, number, number]
   return [r, g, b]
 }
 
-export function luminance(el: Element, color: string) {
+export function luminance(el: Element, color: string | number[]) {
   const [r, g, b] = colorToDec(el, color)
   const a = [r, g, b].map((v) => {
     v /= 255
@@ -49,7 +60,7 @@ export function luminance(el: Element, color: string) {
   return a[0] * RED + a[1] * GREEN + a[2] * BLUE
 }
 
-export function contrast(el, color1: string, color2: string): number {
+export function contrast(el: Element, color1: string | number[], color2: string | number[]): number {
   const lum1 = luminance(el, color1)
   const lum2 = luminance(el, color2)
   const brightest = Math.max(lum1, lum2)


### PR DESCRIPTION
## Summary
- fix `sc-area-card` graph rendering when `color` is configured as a YAML RGB array such as `[142, 26, 26]`
- normalize custom, preset, and fallback colors through the same path so color handling is consistent
- add tests covering hex colors, CSS variable colors, RGB arrays, area preset colors, and the final fallback color

## Root Cause
`sc-area-card` expected `color` to always be a string, but Home Assistant can parse YAML list syntax into a number array. That caused `getBaseColor()` to call `.startsWith()` on a non-string value and break graph rendering.

## Testing
- `pnpm vitest run src/__tests__/utils.test.ts src/__tests__/area-card/AreaCard.test.ts -t "Area Color|getBaseColor"`
- `pnpm tsc --noEmit`
- `pnpm run build`
- `pnpm run test` still has pre-existing unrelated failures in `history-bars-card` and `echarts-wrapper` on `main`
