### PR TITLE
chore(release): automate release PR merging

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,11 +1,11 @@
 name: Auto-merge Release PRs
 
 on:
-  pull_request:
+  workflow_run:
+    workflows:
+      - CI
     types:
-      - opened
-      - synchronize
-      - reopened
+      - completed
 
 permissions:
   contents: write
@@ -14,13 +14,46 @@ permissions:
 jobs:
   auto-merge-release-pr:
     runs-on: ubuntu-latest
-    # Only run on release-please PRs
     if: |
-      github.event.pull_request.user.login == 'github-actions[bot]' &&
-      startsWith(github.event.pull_request.head.ref, 'release-please--')
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
     steps:
-      - name: Enable auto-merge for release PR
-        run: gh pr merge --auto --squash "$PR_URL"
+      - name: Merge release PR after CI passes
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          PR_NUMBER="$(gh api "/repos/$REPO/actions/runs/$RUN_ID" --jq '.pull_requests[0].number // empty')"
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No pull request is associated with this CI run."
+            exit 0
+          fi
+
+          HEAD_REF="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName --jq '.headRefName')"
+          BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json baseRefName --jq '.baseRefName')"
+          IS_DRAFT="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft --jq '.isDraft')"
+          MERGE_STATE="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeStateStatus --jq '.mergeStateStatus')"
+
+          if [[ "$HEAD_REF" != release-please--* ]]; then
+            echo "PR #$PR_NUMBER is not a release-please PR."
+            exit 0
+          fi
+
+          if [ "$BASE_REF" != "main" ]; then
+            echo "PR #$PR_NUMBER does not target main."
+            exit 0
+          fi
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "PR #$PR_NUMBER is still a draft."
+            exit 0
+          fi
+
+          if [[ "$MERGE_STATE" != "CLEAN" && "$MERGE_STATE" != "HAS_HOOKS" && "$MERGE_STATE" != "UNSTABLE" ]]; then
+            echo "PR #$PR_NUMBER is not ready to merge (state: $MERGE_STATE)."
+            exit 0
+          fi
+
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --delete-branch

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,5 +20,5 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          # This uses the default token which has permissions for creating releases
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a dedicated token so release PRs can trigger follow-up workflows.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Provides multiple custom cards for Home Assistant, including a room card and a bars card.
 
+## Automated Releases
+
+This repository uses `release-please` to open a release PR after changes land on `main`.
+When that PR passes `CI`, GitHub Actions merges it automatically, creates the GitHub release, builds the bundle, and uploads `dist/sc-custom-cards.js` as a release asset.
+
+To keep the process fully automatic, add a repository secret named `RELEASE_PLEASE_TOKEN` with permissions to create and merge pull requests, push to `main`, create releases, and trigger follow-up workflows.
+Without that secret, GitHub falls back to `GITHUB_TOKEN`, which usually cannot trigger the PR and push workflows required to finish the full release flow.
+
 ## Table of Contents
 
 - [Installation](#installation)


### PR DESCRIPTION
## Summary
This updates the release automation so merges to `main` can complete the full `release-please` flow without manual approval of the generated release PR.
It switches the release PR merge step to happen automatically after `CI` succeeds and documents the token setup required for the workflow chain to run end to end.

## Changes
### Chores
- update `release-please` to prefer `RELEASE_PLEASE_TOKEN` so release PRs and release commits can trigger follow-up workflows reliably
- replace the PR auto-merge workflow with a `workflow_run` job that merges `release-please` PRs only after `CI` completes successfully
- add merge safeguards so only non-draft `release-please` PRs targeting `main` are merged when GitHub reports a mergeable state
- document the automated release flow and the required `RELEASE_PLEASE_TOKEN` repository secret in `README.md`

## PR Details (AI generated)

### Goals
Make the existing `release-please` setup fully automatic after changes land on `main`, while keeping the current PR-based release flow instead of replacing it with a different release system.

### Changes in detail
#### Chores
The `release-please` workflow now prefers a dedicated `RELEASE_PLEASE_TOKEN` and falls back to `GITHUB_TOKEN` only when that secret is not configured. This addresses the common GitHub Actions limitation where PRs and pushes created with the default token do not trigger the downstream workflows required to finish a PR-based automated release pipeline.

The old release PR automation depended on `gh pr merge --auto` during `pull_request` events. That approach still relies on repository-level auto-merge behavior and did not directly tie merging to successful CI completion. The new workflow instead listens for the `CI` workflow to complete, resolves the associated PR, verifies that it is a `release-please` branch targeting `main`, checks that it is not a draft, and merges it only when GitHub reports a mergeable state.

The README was updated with a short operations note so the release setup is understandable without reading the workflow files. It explains the end-to-end sequence and calls out the external requirement to create the `RELEASE_PLEASE_TOKEN` repository secret.

### Notes
This PR changes the repository automation only. For the flow to be fully automatic in GitHub, the repository still needs a `RELEASE_PLEASE_TOKEN` secret with enough permissions to create and merge PRs, push to `main`, create releases, and trigger follow-up workflows.