### PR TITLE
fix(release): use plain tags for HACS

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
+      "include-component-in-tag": false,
       "include-v-in-tag": true,
       "extra-files": []
     }


### PR DESCRIPTION
## Summary
This restores plain `vX.Y.Z` release tags so HACS can continue detecting new versions consistently.
The recent `release-please` setup started generating component-prefixed tags such as `sc-custom-cards-v1.6.1`, which differs from the repository's historical `v1.6.0` style tags.

## Changes
### Fixes
- configure `release-please` to stop including the component name in generated tags
- preserve the `v` prefix while switching future tags back to the plain `vX.Y.Z` format HACS has historically seen in this repository

## PR Details (AI generated)

### Goals
Fix the release tag format so HACS can detect future updates again without changing the rest of the automated release workflow.

### Changes in detail
#### Fixes
`release-please-config.json` now sets `include-component-in-tag` to `false`. With the existing `include-v-in-tag` setting, future automated releases should produce tags like `v1.6.2` instead of `sc-custom-cards-v1.6.2`.

This is the smallest change that addresses the HACS compatibility issue while keeping the new automated release PR and asset upload flow intact.

### Notes
This fixes future releases. The already-published `sc-custom-cards-v1.6.1` release remains unchanged, so HACS may not show `1.6.1` unless a matching plain `v1.6.1` release is created manually or the next release is published as a plain-tagged version such as `v1.6.2`.