### PR TITLE
feat(release): support beta prereleases

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -41,8 +41,8 @@ jobs:
             exit 0
           fi
 
-          if [ "$BASE_REF" != "main" ]; then
-            echo "PR #$PR_NUMBER does not target main."
+          if [[ "$BASE_REF" != "main" && "$BASE_REF" != "beta" ]]; then
+            echo "PR #$PR_NUMBER does not target a release branch."
             exit 0
           fi
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - beta
 
 permissions:
   contents: write
@@ -22,3 +23,4 @@ jobs:
         with:
           # Use a dedicated token so release PRs can trigger follow-up workflows.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          target-branch: ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,28 @@ Provides multiple custom cards for Home Assistant, including an area card and a 
 This repository uses `release-please` to open a release PR after changes land on `main`.
 When that PR passes `CI`, GitHub Actions merges it automatically, creates the GitHub release, builds the bundle, and uploads `dist/sc-custom-cards.js` as a release asset.
 
+The repository also supports a fully automatic `beta` release channel. Merges to `beta` follow the same flow, but publish prereleases such as `v1.7.1-beta.1` that can be used for testing before promoting changes to `main`.
+
 To keep the process fully automatic, add a repository secret named `RELEASE_PLEASE_TOKEN` with permissions to create and merge pull requests, push to `main`, create releases, and trigger follow-up workflows.
 Without that secret, GitHub falls back to `GITHUB_TOKEN`, which usually cannot trigger the PR and push workflows required to finish the full release flow.
+
+### Beta Channel
+
+Use the long-lived `beta` branch as the prerelease lane.
+
+How it works:
+- open normal feature and fix PRs against `beta` when you want to test changes before shipping them to `main`
+- when a PR is merged into `beta`, `release-please` opens or updates a beta release PR
+- after `CI` succeeds, GitHub Actions merges that release PR automatically
+- the merge publishes a GitHub prerelease and uploads `dist/sc-custom-cards.js`
+
+Version behavior:
+- each merge into `beta` can produce a new prerelease version when there are releasable commits
+- `fix:` commits produce patch prereleases such as `v1.7.1-beta.1`, then `v1.7.1-beta.2`
+- `feat:` commits produce minor prereleases such as `v1.8.0-beta.1`
+- breaking changes produce the next major prerelease version
+
+To test beta versions in HACS, enable beta versions for the repository in HACS before checking for updates.
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary
This adds a fully automatic `beta` prerelease channel alongside the existing stable `main` release flow.
Merges to `beta` will now run `release-please`, auto-merge the generated release PR after `CI` succeeds, and publish GitHub prereleases for testing.

## Changes
### Features
- run the `release-please` workflow on both `main` and `beta`
- pass the current branch as `target-branch` so each release branch manages its own release PRs and tags
- allow the release PR auto-merge workflow to merge release PRs targeting either `main` or `beta`
- document the `beta` prerelease lane and how versioning behaves there

## PR Details (AI generated)

### Goals
Add a testing channel that publishes prereleases automatically from a dedicated `beta` branch without changing the stable release flow on `main`.

### Changes in detail
#### Features
The release workflow now listens to pushes on both `main` and `beta`, and passes `github.ref_name` into `release-please` as `target-branch`. This lets the same workflow support multiple release branches cleanly.

The release PR merge workflow now accepts release PRs targeting either `main` or `beta`. It still keeps the same safeguards: only `release-please` PRs are eligible, drafts are skipped, and GitHub must report a mergeable state.

The README was updated to document the `beta` channel, including how prerelease versions are expected to increment and how to consume them in HACS.

### Notes
This PR adds shared workflow support only. The long-lived `beta` branch also needs its branch-specific prerelease config, which has already been prepared directly on the `beta` branch so prereleases can start immediately after this PR is merged.