### PR TITLE
fix(area-card): support summary actions migration

### DIFF
--- a/src/__tests__/area-card/AreaCard.test.ts
+++ b/src/__tests__/area-card/AreaCard.test.ts
@@ -79,6 +79,57 @@ describe('ScAreaCard', () => {
       const result = element['summaryTypes']
       expect(result.length).toBe(2)
     })
+
+    it('should read summary actions from nested actions config', () => {
+      const config = createMockAreaCardConfig({
+        summary: [
+          createMockEntitySummary({
+            actions: {
+              tap_action: { action: 'more-info' },
+            },
+            tap_action: undefined,
+          }),
+        ],
+      })
+
+      element.setConfig(config)
+      element.hass = mockHass
+
+      expect(element['summaryTypes'][0].tap_action).toEqual({ action: 'more-info' })
+    })
+
+    it('should keep legacy flat summary actions working', () => {
+      const config = createMockAreaCardConfig({
+        summary: [
+          createMockEntitySummary({
+            tap_action: { action: 'more-info' },
+          }),
+        ],
+      })
+
+      element.setConfig(config)
+      element.hass = mockHass
+
+      expect(element['summaryTypes'][0].tap_action).toEqual({ action: 'more-info' })
+    })
+
+    it('should prefer nested summary actions over legacy flat ones', () => {
+      const config = createMockAreaCardConfig({
+        summary: [
+          createMockEntitySummary({
+            actions: {
+              tap_action: { action: 'toggle' },
+            },
+            tap_action: { action: 'more-info' },
+          }),
+        ],
+      })
+
+      element.setConfig(config)
+      element.hass = mockHass
+
+      expect(element['summaryTypes'][0].tap_action).toEqual({ action: 'toggle' })
+    })
   })
 
   describe('Area Color', () => {

--- a/src/__tests__/area-card/AreaCardEditor.test.ts
+++ b/src/__tests__/area-card/AreaCardEditor.test.ts
@@ -45,6 +45,51 @@ describe('ScAreaCardEditor', () => {
       expect(element['_config']?.presence).toBeUndefined()
       expect(element['_config']?.light).toBeUndefined()
     })
+
+    it('should migrate legacy flat summary actions to nested actions', () => {
+      const config = createMockAreaCardConfig({
+        summary: [
+          createMockEntitySummary({
+            tap_action: { action: 'more-info' },
+            hold_action: { action: 'toggle' },
+          }),
+        ],
+      })
+
+      element.setConfig(config)
+
+      expect(element['_config']?.summary).toEqual([
+        expect.objectContaining({
+          actions: {
+            tap_action: { action: 'more-info' },
+            hold_action: { action: 'toggle' },
+            double_tap_action: undefined,
+          },
+        }),
+      ])
+      expect((element['_summaryList'][0] as any).tap_action).toBeUndefined()
+      expect((element['_summaryList'][0] as any).hold_action).toBeUndefined()
+    })
+
+    it('should preserve nested summary actions when already present', () => {
+      const config = createMockAreaCardConfig({
+        summary: [
+          createMockEntitySummary({
+            actions: {
+              tap_action: { action: 'toggle' },
+            },
+            tap_action: { action: 'more-info' },
+          }),
+        ],
+      })
+
+      element.setConfig(config)
+
+      expect(element['_summaryList'][0].actions).toEqual({
+        tap_action: { action: 'toggle' },
+      })
+      expect((element['_summaryList'][0] as any).tap_action).toBeUndefined()
+    })
   })
 
   describe('Summary Management', () => {
@@ -382,6 +427,7 @@ describe('ScAreaCardEditor', () => {
   describe('Migration Logic', () => {
     it('should migrate all preset types', () => {
       const config = createMockAreaCardConfig({
+        summary: [],
         presence: 'sensor.presence',
         alarm: ['sensor.alarm1', 'sensor.alarm2'],
         door: 'sensor.door',
@@ -401,6 +447,7 @@ describe('ScAreaCardEditor', () => {
 
     it('should not create migration summaries for empty preset fields', () => {
       const config = createMockAreaCardConfig({
+        summary: [],
         presence: [],
         alarm: undefined,
       } as any)

--- a/src/area-card/AreaCard.ts
+++ b/src/area-card/AreaCard.ts
@@ -82,6 +82,14 @@ export class ScAreaCard extends LitElement {
     return Array.isArray(value) ? value : [value]
   }
 
+  private normalizeSummaryActions(type: EntityTypeSummary) {
+    return {
+      tap_action: type.actions?.tap_action ?? type.tap_action,
+      hold_action: type.actions?.hold_action ?? type.hold_action,
+      double_tap_action: type.actions?.double_tap_action ?? type.double_tap_action,
+    }
+  }
+
   // lifecycle interface
   setConfig(config: ScAreaCardConfig) {
     this._config = config
@@ -141,14 +149,16 @@ export class ScAreaCard extends LitElement {
     }
 
     const customSummaries: EntityTypeSummary[] = this.toArray(this._config?.summary).map((type) => {
+      const actions = this.normalizeSummaryActions(type)
       return {
         name: type.name,
         icon: type.icon || 'mdi:help-circle',
         entities: this.toArray(type.entities),
         alarm_entities: this.toArray(type.alarm_entities),
-        tap_action: type.tap_action,
-        hold_action: type.hold_action,
-        double_tap_action: type.double_tap_action,
+        actions,
+        tap_action: actions.tap_action,
+        hold_action: actions.hold_action,
+        double_tap_action: actions.double_tap_action,
       }
     })
 

--- a/src/area-card/AreaCardEditor.ts
+++ b/src/area-card/AreaCardEditor.ts
@@ -33,7 +33,35 @@ export class ScAreaCardEditor extends LitElement {
 
   private _sanitizeConfig(config: ScAreaCardConfig): ScAreaCardConfig {
     const { _stubPreview, ...sanitizedConfig } = config
-    return sanitizedConfig
+
+    if (!sanitizedConfig.summary) {
+      return sanitizedConfig
+    }
+
+    const summary = this._toArray(sanitizedConfig.summary).map((item) => {
+      const actions = item.actions ??
+        (item.tap_action || item.hold_action || item.double_tap_action
+          ? {
+              tap_action: item.tap_action,
+              hold_action: item.hold_action,
+              double_tap_action: item.double_tap_action,
+            }
+          : undefined)
+
+      const {
+        tap_action: _tapAction,
+        hold_action: _holdAction,
+        double_tap_action: _doubleTapAction,
+        ...summaryWithoutLegacyActions
+      } = item
+
+      return actions ? { ...summaryWithoutLegacyActions, actions } : summaryWithoutLegacyActions
+    })
+
+    return {
+      ...sanitizedConfig,
+      summary: Array.isArray(sanitizedConfig.summary) ? summary : summary[0],
+    }
   }
 
   private _migratePresetsToSummaries(config: ScAreaCardConfig): ScAreaCardConfig {

--- a/src/area-card/types.ts
+++ b/src/area-card/types.ts
@@ -5,6 +5,11 @@ export type EntityTypeSummary = {
   icon: string
   entities: string | string[]
   alarm_entities?: string | string[]
+  actions?: {
+    tap_action?: ActionConfig
+    hold_action?: ActionConfig
+    double_tap_action?: ActionConfig
+  }
   tap_action?: ActionConfig
   hold_action?: ActionConfig
   double_tap_action?: ActionConfig


### PR DESCRIPTION
## Summary
- make area card summary widgets read both legacy flat actions and the editor's nested `actions` object
- migrate legacy summary action fields into `summary[].actions` when the UI editor opens so saved configs become canonical
- add tests covering nested actions, legacy compatibility, and migration precedence

## Testing
- pnpm vitest run src/__tests__/area-card/AreaCard.test.ts -t \"summary actions\"
- pnpm vitest run src/__tests__/area-card/AreaCardEditor.test.ts -t \"summary actions|migrate legacy flat summary actions|preserve nested summary actions|migrate all preset types|not create migration summaries\"
- pnpm build